### PR TITLE
IO-55

### DIFF
--- a/WebApi/IntegrationTest/APITest/API.cs
+++ b/WebApi/IntegrationTest/APITest/API.cs
@@ -1,0 +1,36 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+
+namespace IntegrationTest.APITest
+{
+    public static class API
+    {
+        static Dictionary<string, HttpClient> clients = new Dictionary<string, HttpClient>()
+        {
+            ["I"] = new HttpClient { BaseAddress = new Uri("https://webapi20210317153051.azurewebsites.net/") },
+            ["D"] = new HttpClient { BaseAddress = new Uri("https://salesystemapi.azurewebsites.net/") },
+            ["K"] = new HttpClient { BaseAddress = new Uri("https://serverappats.azurewebsites.net/") }
+        };
+
+        public static HttpClient client = clients["I"];
+
+        public static HttpRequestMessage CreateRequest(HttpMethod method, string requestUri, object expected = null)
+        {
+            HttpRequestMessage requestMessage = new HttpRequestMessage(method, requestUri);
+            requestMessage.Headers.Add("userId", "1"); //można zparametryzować
+
+            string jsonPost = JsonConvert.SerializeObject(expected);
+            requestMessage.Content = new StringContent(jsonPost, Encoding.UTF8, "application/json");
+
+            return requestMessage;
+        }
+
+        
+
+    }
+
+}

--- a/WebApi/IntegrationTest/APITest/CategoryAPITest.cs
+++ b/WebApi/IntegrationTest/APITest/CategoryAPITest.cs
@@ -1,0 +1,33 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using WebApi.Models.DTO;
+using Xunit;
+
+namespace IntegrationTest.APITest
+{
+
+    public class CategoryAPITest
+    {
+        [Fact]
+        public async void Categories_ValidCall()
+        {
+            var requestMessage = API.CreateRequest(HttpMethod.Get, "categories");
+            var result = await API.client.SendAsync(requestMessage);
+            var jsonString = await result.Content.ReadAsStringAsync();
+            var actual = JsonConvert.DeserializeObject<Categories>(jsonString);
+
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+            Assert.NotNull(actual);
+            Assert.NotEmpty(actual.categories);
+            foreach (var category in actual.categories)
+            {
+                Assert.NotNull(category.Name);
+                Assert.NotEqual("", category.Name);
+            }
+        }
+    }
+}

--- a/WebApi/IntegrationTest/APITest/PostAPITest.cs
+++ b/WebApi/IntegrationTest/APITest/PostAPITest.cs
@@ -7,16 +7,10 @@ using System.Text;
 using WebApi.Models.DTO;
 using Xunit;
 
-namespace IntegrationTest
+namespace IntegrationTest.APITest
 {
     public class PostAPITest
-    {
-
-        HttpClient client = new HttpClient
-        {
-            BaseAddress = new Uri("https://webapi20210317153051.azurewebsites.net/")
-        };
-
+    { 
         public PostAPI getPost(string content)
         {
             return new PostAPI {
@@ -29,55 +23,45 @@ namespace IntegrationTest
             };
         }
 
-        public HttpRequestMessage CreateRequest(HttpMethod method, string requestUri, object expected = null)
-        {
-            HttpRequestMessage requestMessage = new HttpRequestMessage(method, requestUri);
-            requestMessage.Headers.Add("userId", "1"); //można zparametryzować
-
-            string jsonPost = JsonConvert.SerializeObject(expected);
-            requestMessage.Content = new StringContent(jsonPost, Encoding.UTF8, "application/json");
-
-            return requestMessage;
-        }
 
         [Fact]
         public async void Post_ValidCall()
         {
             //POST
             var expectedPost = getPost("before edit");
-            var PostRequestMessage = CreateRequest(HttpMethod.Post, "post", expectedPost);
-            var PostResult = await client.SendAsync(PostRequestMessage);
+            var PostRequestMessage = API.CreateRequest(HttpMethod.Post, "post", expectedPost);
+            var PostResult = await API.client.SendAsync(PostRequestMessage);
             var PostJsonString = await PostResult.Content.ReadAsStringAsync();
             var postID = JsonConvert.DeserializeObject<int>(PostJsonString);
 
             //GET
-            var beforePutGetRequestMessage = CreateRequest(HttpMethod.Get, $"post/{postID}");
-            var beforePutGetResult = await client.SendAsync(beforePutGetRequestMessage);
+            var beforePutGetRequestMessage = API.CreateRequest(HttpMethod.Get, $"post/{postID}");
+            var beforePutGetResult = await API.client.SendAsync(beforePutGetRequestMessage);
             var beforePutJsonString = await beforePutGetResult.Content.ReadAsStringAsync();
             var beforePutPost = JsonConvert.DeserializeObject<PostDTO>(beforePutJsonString);
 
             //PUT
             var editedPost = getPost("edited");
-            var PutRequestMessage = CreateRequest(HttpMethod.Put, $"post/{postID}", editedPost);
-            var PutResult = await client.SendAsync(PutRequestMessage);
+            var PutRequestMessage = API.CreateRequest(HttpMethod.Put, $"post/{postID}", editedPost);
+            var PutResult = await API.client.SendAsync(PutRequestMessage);
             var PutJsonString = await PutResult.Content.ReadAsStringAsync();
             var isEdited = JsonConvert.DeserializeObject<bool>(PutJsonString);
 
             //GET
-            var afterPutGetRequestMessage = CreateRequest(HttpMethod.Get, $"post/{postID}");
-            var afterPutGetResult = await client.SendAsync(afterPutGetRequestMessage);
+            var afterPutGetRequestMessage = API.CreateRequest(HttpMethod.Get, $"post/{postID}");
+            var afterPutGetResult = await API.client.SendAsync(afterPutGetRequestMessage);
             var afterPutJsonString = await afterPutGetResult.Content.ReadAsStringAsync();
             var afterPutPost = JsonConvert.DeserializeObject<PostDTO>(afterPutJsonString);
 
             //DELETE
-            var DeleteRequestMessage = CreateRequest(HttpMethod.Delete, $"post/{postID}");
-            var DeleteResult = await client.SendAsync(DeleteRequestMessage);
+            var DeleteRequestMessage = API.CreateRequest(HttpMethod.Delete, $"post/{postID}");
+            var DeleteResult = await API.client.SendAsync(DeleteRequestMessage);
             var DeleteJsonString = await DeleteResult.Content.ReadAsStringAsync();
             var isDeleted = JsonConvert.DeserializeObject<bool>(DeleteJsonString);
 
             //GET
-            var afterDeleteGetRequestMessage = CreateRequest(HttpMethod.Get, $"post/{postID}");
-            var afterDeleteGetResult = await client.SendAsync(afterDeleteGetRequestMessage);
+            var afterDeleteGetRequestMessage = API.CreateRequest(HttpMethod.Get, $"post/{postID}");
+            var afterDeleteGetResult = await API.client.SendAsync(afterDeleteGetRequestMessage);
 
             Assert.Equal(HttpStatusCode.OK, PostResult.StatusCode);
             Assert.Equal(HttpStatusCode.OK, beforePutGetResult.StatusCode);
@@ -96,46 +80,46 @@ namespace IntegrationTest
         public async void AllPosts_ValidCall()
         {
             //GET all
-            var beforePostGetRequestMessage = CreateRequest(HttpMethod.Get, "post");
-            var beforePostGetResult = await client.SendAsync(beforePostGetRequestMessage);
+            var beforePostGetRequestMessage = API.CreateRequest(HttpMethod.Get, "posts");
+            var beforePostGetResult = await API.client.SendAsync(beforePostGetRequestMessage);
             var beforePostJsonString = await beforePostGetResult.Content.ReadAsStringAsync();
             List<PostAPI> beforePostPosts = JsonConvert.DeserializeObject<List<PostAPI>>(beforePostJsonString);
 
             //POST
             var expectedPost = getPost("before edit");
-            var PostRequestMessage = CreateRequest(HttpMethod.Post, "post", expectedPost);
-            var PostResult = await client.SendAsync(PostRequestMessage);
+            var PostRequestMessage = API.CreateRequest(HttpMethod.Post, "post", expectedPost);
+            var PostResult = await API.client.SendAsync(PostRequestMessage);
             var PostJsonString = await PostResult.Content.ReadAsStringAsync();
             var postID = JsonConvert.DeserializeObject<int>(PostJsonString);
 
             //GET all
-            var afterPostGetRequestMessage = CreateRequest(HttpMethod.Get, "post");
-            var afterPostGetResult = await client.SendAsync(afterPostGetRequestMessage);
+            var afterPostGetRequestMessage = API.CreateRequest(HttpMethod.Get, "posts");
+            var afterPostGetResult = await API.client.SendAsync(afterPostGetRequestMessage);
             var afterPostJsonString = await afterPostGetResult.Content.ReadAsStringAsync();
             List<PostAPI> afterPostPosts = JsonConvert.DeserializeObject<List<PostAPI>>(afterPostJsonString);
 
             //PUT
             var editedPost = getPost("edited");
-            var PutRequestMessage = CreateRequest(HttpMethod.Put, $"post/{postID}", editedPost);
-            var PutResult = await client.SendAsync(PutRequestMessage);
+            var PutRequestMessage = API.CreateRequest(HttpMethod.Put, $"post/{postID}", editedPost);
+            var PutResult = await API.client.SendAsync(PutRequestMessage);
             var PutJsonString = await PutResult.Content.ReadAsStringAsync();
             var isEdited = JsonConvert.DeserializeObject<bool>(PutJsonString);
 
             //GET all
-            var afterPutGetRequestMessage = CreateRequest(HttpMethod.Get, "post");
-            var afterPutGetResult = await client.SendAsync(afterPutGetRequestMessage);
+            var afterPutGetRequestMessage = API.CreateRequest(HttpMethod.Get, "posts");
+            var afterPutGetResult = await API.client.SendAsync(afterPutGetRequestMessage);
             var afterPutJsonString = await afterPutGetResult.Content.ReadAsStringAsync();
             List<PostAPI> afterPutPosts = JsonConvert.DeserializeObject<List<PostAPI>>(afterPutJsonString);
 
             //DELETE
-            var DeleteRequestMessage = CreateRequest(HttpMethod.Delete, $"post/{postID}");
-            var DeleteResult = await client.SendAsync(DeleteRequestMessage);
+            var DeleteRequestMessage = API.CreateRequest(HttpMethod.Delete, $"post/{postID}");
+            var DeleteResult = await API.client.SendAsync(DeleteRequestMessage);
             var DeleteJsonString = await DeleteResult.Content.ReadAsStringAsync();
             var isDeleted = JsonConvert.DeserializeObject<bool>(DeleteJsonString);
 
             //GET all
-            var afterDeleteGetRequestMessage = CreateRequest(HttpMethod.Get, "post");
-            var afterDeleteGetResult = await client.SendAsync(afterDeleteGetRequestMessage);
+            var afterDeleteGetRequestMessage = API.CreateRequest(HttpMethod.Get, "posts");
+            var afterDeleteGetResult = await API.client.SendAsync(afterDeleteGetRequestMessage);
             var afterDeleteJsonString = await afterDeleteGetResult.Content.ReadAsStringAsync();
             List<PostAPI> afterDeletePosts = JsonConvert.DeserializeObject<List<PostAPI>>(afterDeleteJsonString);
 
@@ -163,8 +147,8 @@ namespace IntegrationTest
             //POST
             var expectedPost = getPost("content");
                 expectedPost.Content = null;
-            var PostRequestMessage = CreateRequest(HttpMethod.Post, "post", expectedPost);
-            var PostResult = await client.SendAsync(PostRequestMessage);
+            var PostRequestMessage = API.CreateRequest(HttpMethod.Post, "post", expectedPost);
+            var PostResult = await API.client.SendAsync(PostRequestMessage);
 
             Assert.Equal(HttpStatusCode.BadRequest, PostResult.StatusCode);
         }
@@ -175,8 +159,8 @@ namespace IntegrationTest
             //POST
             var expectedPost = getPost("content");
                 expectedPost.Title = null;
-            var PostRequestMessage = CreateRequest(HttpMethod.Post, "post", expectedPost);
-            var PostResult = await client.SendAsync(PostRequestMessage);
+            var PostRequestMessage = API.CreateRequest(HttpMethod.Post, "post", expectedPost);
+            var PostResult = await API.client.SendAsync(PostRequestMessage);
 
             Assert.Equal(HttpStatusCode.BadRequest, PostResult.StatusCode);
         }
@@ -187,8 +171,8 @@ namespace IntegrationTest
             //POST
             var expectedPost = getPost("content");
             expectedPost.Category = null;
-            var PostRequestMessage = CreateRequest(HttpMethod.Post, "post", expectedPost);
-            var PostResult = await client.SendAsync(PostRequestMessage);
+            var PostRequestMessage = API.CreateRequest(HttpMethod.Post, "post", expectedPost);
+            var PostResult = await API.client.SendAsync(PostRequestMessage);
 
             Assert.Equal(HttpStatusCode.BadRequest, PostResult.StatusCode);
         }
@@ -199,8 +183,8 @@ namespace IntegrationTest
             //POST
             var expectedPost = getPost("content");
             expectedPost.IsPromoted = null;
-            var PostRequestMessage = CreateRequest(HttpMethod.Post, "post", expectedPost);
-            var PostResult = await client.SendAsync(PostRequestMessage);
+            var PostRequestMessage = API.CreateRequest(HttpMethod.Post, "post", expectedPost);
+            var PostResult = await API.client.SendAsync(PostRequestMessage);
 
             Assert.Equal(HttpStatusCode.BadRequest, PostResult.StatusCode);
         }
@@ -210,8 +194,8 @@ namespace IntegrationTest
             //POST
             var expectedPost = getPost("content");
             expectedPost.Datetime = null;
-            var PostRequestMessage = CreateRequest(HttpMethod.Post, "post", expectedPost);
-            var PostResult = await client.SendAsync(PostRequestMessage);
+            var PostRequestMessage = API.CreateRequest(HttpMethod.Post, "post", expectedPost);
+            var PostResult = await API.client.SendAsync(PostRequestMessage);
 
             Assert.Equal(HttpStatusCode.BadRequest, PostResult.StatusCode);
         }
@@ -221,9 +205,9 @@ namespace IntegrationTest
         {
             //POST
             var expectedPost = getPost("content");
-            var PostRequestMessage = CreateRequest(HttpMethod.Post, "post", expectedPost);
+            var PostRequestMessage = API.CreateRequest(HttpMethod.Post, "post", expectedPost);
             PostRequestMessage.Headers.Clear();
-            var PostResult = await client.SendAsync(PostRequestMessage);
+            var PostResult = await API.client.SendAsync(PostRequestMessage);
             var jsonString = await PostResult.Content.ReadAsStringAsync();
 
             Assert.Equal(HttpStatusCode.BadRequest, PostResult.StatusCode);
@@ -234,19 +218,19 @@ namespace IntegrationTest
         {
             //POST
             var expectedPost = getPost("content");
-            var PostRequestMessage = CreateRequest(HttpMethod.Post, "post", expectedPost);
-            var PostResult = await client.SendAsync(PostRequestMessage);
+            var PostRequestMessage = API.CreateRequest(HttpMethod.Post, "post", expectedPost);
+            var PostResult = await API.client.SendAsync(PostRequestMessage);
             var PostJsonString = await PostResult.Content.ReadAsStringAsync();
             var postID = JsonConvert.DeserializeObject<int>(PostJsonString);
 
             //DELETE Invalid
-            var InvalidDeleteRequestMessage = CreateRequest(HttpMethod.Delete, $"post/{postID}");
+            var InvalidDeleteRequestMessage = API.CreateRequest(HttpMethod.Delete, $"post/{postID}");
                 InvalidDeleteRequestMessage.Headers.Clear();
-            var InvalidDeleteResult = await client.SendAsync(InvalidDeleteRequestMessage);
+            var InvalidDeleteResult = await API.client.SendAsync(InvalidDeleteRequestMessage);
 
             //DELETE Valid
-            var ValidDeleteRequestMessage = CreateRequest(HttpMethod.Delete, $"post/{postID}");
-            var ValidDeleteResult = await client.SendAsync(ValidDeleteRequestMessage);
+            var ValidDeleteRequestMessage = API.CreateRequest(HttpMethod.Delete, $"post/{postID}");
+            var ValidDeleteResult = await API.client.SendAsync(ValidDeleteRequestMessage);
             var ValidDeleteJsonString = await ValidDeleteResult.Content.ReadAsStringAsync();
             var isDeleted = JsonConvert.DeserializeObject<bool>(ValidDeleteJsonString);
 
@@ -261,20 +245,20 @@ namespace IntegrationTest
         {
             //POST
             var expectedPost = getPost("content");
-            var PostRequestMessage = CreateRequest(HttpMethod.Post, "post", expectedPost);
-            var PostResult = await client.SendAsync(PostRequestMessage);
+            var PostRequestMessage = API.CreateRequest(HttpMethod.Post, "post", expectedPost);
+            var PostResult = await API.client.SendAsync(PostRequestMessage);
             var PostJsonString = await PostResult.Content.ReadAsStringAsync();
             var postID = JsonConvert.DeserializeObject<int>(PostJsonString);
 
             //DELETE Valid
-            var ValidDeleteRequestMessage = CreateRequest(HttpMethod.Delete, $"post/{postID}");
-            var ValidDeleteResult = await client.SendAsync(ValidDeleteRequestMessage);
+            var ValidDeleteRequestMessage = API.CreateRequest(HttpMethod.Delete, $"post/{postID}");
+            var ValidDeleteResult = await API.client.SendAsync(ValidDeleteRequestMessage);
             var ValidDeleteJsonString = await ValidDeleteResult.Content.ReadAsStringAsync();
             var isDeleted = JsonConvert.DeserializeObject<bool>(ValidDeleteJsonString);
 
             //DELETE Invalid
-            var InvalidDeleteRequestMessage = CreateRequest(HttpMethod.Delete, $"post/{postID}");
-            var InvalidDeleteResult = await client.SendAsync(InvalidDeleteRequestMessage);
+            var InvalidDeleteRequestMessage = API.CreateRequest(HttpMethod.Delete, $"post/{postID}");
+            var InvalidDeleteResult = await API.client.SendAsync(InvalidDeleteRequestMessage);
 
             Assert.Equal(HttpStatusCode.OK, PostResult.StatusCode);
             Assert.Equal(HttpStatusCode.OK, ValidDeleteResult.StatusCode);
@@ -288,20 +272,20 @@ namespace IntegrationTest
         {
             //POST
             var expectedPost = getPost("content");
-            var PostRequestMessage = CreateRequest(HttpMethod.Post, "post", expectedPost);
-            var PostResult = await client.SendAsync(PostRequestMessage);
+            var PostRequestMessage = API.CreateRequest(HttpMethod.Post, "post", expectedPost);
+            var PostResult = await API.client.SendAsync(PostRequestMessage);
             var PostJsonString = await PostResult.Content.ReadAsStringAsync();
             var postID = JsonConvert.DeserializeObject<int>(PostJsonString);
 
             //PUT
             var editedPost = getPost("edited");
                 editedPost.Title = null;
-            var PutRequestMessage = CreateRequest(HttpMethod.Put, $"post/{postID}", editedPost);
-            var PutResult = await client.SendAsync(PutRequestMessage);
+            var PutRequestMessage = API.CreateRequest(HttpMethod.Put, $"post/{postID}", editedPost);
+            var PutResult = await API.client.SendAsync(PutRequestMessage);
 
             //DELETE
-            var DeleteRequestMessage = CreateRequest(HttpMethod.Delete, $"post/{postID}");
-            var DeleteResult = await client.SendAsync(DeleteRequestMessage);
+            var DeleteRequestMessage = API.CreateRequest(HttpMethod.Delete, $"post/{postID}");
+            var DeleteResult = await API.client.SendAsync(DeleteRequestMessage);
             var DeleteJsonString = await DeleteResult.Content.ReadAsStringAsync();
             var isDeleted = JsonConvert.DeserializeObject<bool>(DeleteJsonString);
 
@@ -316,20 +300,20 @@ namespace IntegrationTest
         {
             //POST
             var expectedPost = getPost("content");
-            var PostRequestMessage = CreateRequest(HttpMethod.Post, "post", expectedPost);
-            var PostResult = await client.SendAsync(PostRequestMessage);
+            var PostRequestMessage = API.CreateRequest(HttpMethod.Post, "post", expectedPost);
+            var PostResult = await API.client.SendAsync(PostRequestMessage);
             var PostJsonString = await PostResult.Content.ReadAsStringAsync();
             var postID = JsonConvert.DeserializeObject<int>(PostJsonString);
 
             //PUT
             var editedPost = getPost("edited");
             editedPost.Content = null;
-            var PutRequestMessage = CreateRequest(HttpMethod.Put, $"post/{postID}", editedPost);
-            var PutResult = await client.SendAsync(PutRequestMessage);
+            var PutRequestMessage = API.CreateRequest(HttpMethod.Put, $"post/{postID}", editedPost);
+            var PutResult = await API.client.SendAsync(PutRequestMessage);
 
             //DELETE
-            var DeleteRequestMessage = CreateRequest(HttpMethod.Delete, $"post/{postID}");
-            var DeleteResult = await client.SendAsync(DeleteRequestMessage);
+            var DeleteRequestMessage = API.CreateRequest(HttpMethod.Delete, $"post/{postID}");
+            var DeleteResult = await API.client.SendAsync(DeleteRequestMessage);
             var DeleteJsonString = await DeleteResult.Content.ReadAsStringAsync();
             var isDeleted = JsonConvert.DeserializeObject<bool>(DeleteJsonString);
 
@@ -344,20 +328,20 @@ namespace IntegrationTest
         {
             //POST
             var expectedPost = getPost("content");
-            var PostRequestMessage = CreateRequest(HttpMethod.Post, "post", expectedPost);
-            var PostResult = await client.SendAsync(PostRequestMessage);
+            var PostRequestMessage = API.CreateRequest(HttpMethod.Post, "post", expectedPost);
+            var PostResult = await API.client.SendAsync(PostRequestMessage);
             var PostJsonString = await PostResult.Content.ReadAsStringAsync();
             var postID = JsonConvert.DeserializeObject<int>(PostJsonString);
 
             //PUT
             var editedPost = getPost("edited");
             editedPost.Datetime = null;
-            var PutRequestMessage = CreateRequest(HttpMethod.Put, $"post/{postID}", editedPost);
-            var PutResult = await client.SendAsync(PutRequestMessage);
+            var PutRequestMessage = API.CreateRequest(HttpMethod.Put, $"post/{postID}", editedPost);
+            var PutResult = await API.client.SendAsync(PutRequestMessage);
 
             //DELETE
-            var DeleteRequestMessage = CreateRequest(HttpMethod.Delete, $"post/{postID}");
-            var DeleteResult = await client.SendAsync(DeleteRequestMessage);
+            var DeleteRequestMessage = API.CreateRequest(HttpMethod.Delete, $"post/{postID}");
+            var DeleteResult = await API.client.SendAsync(DeleteRequestMessage);
             var DeleteJsonString = await DeleteResult.Content.ReadAsStringAsync();
             var isDeleted = JsonConvert.DeserializeObject<bool>(DeleteJsonString);
 
@@ -372,20 +356,20 @@ namespace IntegrationTest
         {
             //POST
             var expectedPost = getPost("content");
-            var PostRequestMessage = CreateRequest(HttpMethod.Post, "post", expectedPost);
-            var PostResult = await client.SendAsync(PostRequestMessage);
+            var PostRequestMessage = API.CreateRequest(HttpMethod.Post, "post", expectedPost);
+            var PostResult = await API.client.SendAsync(PostRequestMessage);
             var PostJsonString = await PostResult.Content.ReadAsStringAsync();
             var postID = JsonConvert.DeserializeObject<int>(PostJsonString);
 
             //PUT
             var editedPost = getPost("edited");
             editedPost.Category = null;
-            var PutRequestMessage = CreateRequest(HttpMethod.Put, $"post/{postID}", editedPost);
-            var PutResult = await client.SendAsync(PutRequestMessage);
+            var PutRequestMessage = API.CreateRequest(HttpMethod.Put, $"post/{postID}", editedPost);
+            var PutResult = await API.client.SendAsync(PutRequestMessage);
 
             //DELETE
-            var DeleteRequestMessage = CreateRequest(HttpMethod.Delete, $"post/{postID}");
-            var DeleteResult = await client.SendAsync(DeleteRequestMessage);
+            var DeleteRequestMessage = API.CreateRequest(HttpMethod.Delete, $"post/{postID}");
+            var DeleteResult = await API.client.SendAsync(DeleteRequestMessage);
             var DeleteJsonString = await DeleteResult.Content.ReadAsStringAsync();
             var isDeleted = JsonConvert.DeserializeObject<bool>(DeleteJsonString);
 
@@ -400,20 +384,20 @@ namespace IntegrationTest
         {
             //POST
             var expectedPost = getPost("content");
-            var PostRequestMessage = CreateRequest(HttpMethod.Post, "post", expectedPost);
-            var PostResult = await client.SendAsync(PostRequestMessage);
+            var PostRequestMessage = API.CreateRequest(HttpMethod.Post, "post", expectedPost);
+            var PostResult = await API.client.SendAsync(PostRequestMessage);
             var PostJsonString = await PostResult.Content.ReadAsStringAsync();
             var postID = JsonConvert.DeserializeObject<int>(PostJsonString);
 
             //PUT
             var editedPost = getPost("edited");
             editedPost.IsPromoted = null;
-            var PutRequestMessage = CreateRequest(HttpMethod.Put, $"post/{postID}", editedPost);
-            var PutResult = await client.SendAsync(PutRequestMessage);
+            var PutRequestMessage = API.CreateRequest(HttpMethod.Put, $"post/{postID}", editedPost);
+            var PutResult = await API.client.SendAsync(PutRequestMessage);
 
             //DELETE
-            var DeleteRequestMessage = CreateRequest(HttpMethod.Delete, $"post/{postID}");
-            var DeleteResult = await client.SendAsync(DeleteRequestMessage);
+            var DeleteRequestMessage = API.CreateRequest(HttpMethod.Delete, $"post/{postID}");
+            var DeleteResult = await API.client.SendAsync(DeleteRequestMessage);
             var DeleteJsonString = await DeleteResult.Content.ReadAsStringAsync();
             var isDeleted = JsonConvert.DeserializeObject<bool>(DeleteJsonString);
 
@@ -428,20 +412,20 @@ namespace IntegrationTest
         {
             //POST
             var expectedPost = getPost("content");
-            var PostRequestMessage = CreateRequest(HttpMethod.Post, "post", expectedPost);
-            var PostResult = await client.SendAsync(PostRequestMessage);
+            var PostRequestMessage = API.CreateRequest(HttpMethod.Post, "post", expectedPost);
+            var PostResult = await API.client.SendAsync(PostRequestMessage);
             var PostJsonString = await PostResult.Content.ReadAsStringAsync();
             var postID = JsonConvert.DeserializeObject<int>(PostJsonString);
 
             //PUT
             var editedPost = getPost("edited");
-            var PutRequestMessage = CreateRequest(HttpMethod.Put, $"post/{postID}", editedPost);
+            var PutRequestMessage = API.CreateRequest(HttpMethod.Put, $"post/{postID}", editedPost);
                 PutRequestMessage.Headers.Clear();
-            var PutResult = await client.SendAsync(PutRequestMessage);
+            var PutResult = await API.client.SendAsync(PutRequestMessage);
 
             //DELETE
-            var DeleteRequestMessage = CreateRequest(HttpMethod.Delete, $"post/{postID}");
-            var DeleteResult = await client.SendAsync(DeleteRequestMessage);
+            var DeleteRequestMessage = API.CreateRequest(HttpMethod.Delete, $"post/{postID}");
+            var DeleteResult = await API.client.SendAsync(DeleteRequestMessage);
             var DeleteJsonString = await DeleteResult.Content.ReadAsStringAsync();
             var isDeleted = JsonConvert.DeserializeObject<bool>(DeleteJsonString);
 
@@ -456,21 +440,21 @@ namespace IntegrationTest
         {
             //POST
             var expectedPost = getPost("content");
-            var PostRequestMessage = CreateRequest(HttpMethod.Post, "post", expectedPost);
-            var PostResult = await client.SendAsync(PostRequestMessage);
+            var PostRequestMessage = API.CreateRequest(HttpMethod.Post, "post", expectedPost);
+            var PostResult = await API.client.SendAsync(PostRequestMessage);
             var PostJsonString = await PostResult.Content.ReadAsStringAsync();
             var postID = JsonConvert.DeserializeObject<int>(PostJsonString);
 
             //DELETE
-            var DeleteRequestMessage = CreateRequest(HttpMethod.Delete, $"post/{postID}");
-            var DeleteResult = await client.SendAsync(DeleteRequestMessage);
+            var DeleteRequestMessage = API.CreateRequest(HttpMethod.Delete, $"post/{postID}");
+            var DeleteResult = await API.client.SendAsync(DeleteRequestMessage);
             var DeleteJsonString = await DeleteResult.Content.ReadAsStringAsync();
             var isDeleted = JsonConvert.DeserializeObject<bool>(DeleteJsonString);
 
             //PUT
             var editedPost = getPost("edited");
-            var PutRequestMessage = CreateRequest(HttpMethod.Put, $"post/{postID}", editedPost);
-            var PutResult = await client.SendAsync(PutRequestMessage);
+            var PutRequestMessage = API.CreateRequest(HttpMethod.Put, $"post/{postID}", editedPost);
+            var PutResult = await API.client.SendAsync(PutRequestMessage);
 
             Assert.Equal(HttpStatusCode.OK, PostResult.StatusCode);
             Assert.Equal(HttpStatusCode.OK, DeleteResult.StatusCode);
@@ -483,20 +467,20 @@ namespace IntegrationTest
         {
             //POST
             var expectedPost = getPost("content");
-            var PostRequestMessage = CreateRequest(HttpMethod.Post, "post", expectedPost);
-            var PostResult = await client.SendAsync(PostRequestMessage);
+            var PostRequestMessage = API.CreateRequest(HttpMethod.Post, "post", expectedPost);
+            var PostResult = await API.client.SendAsync(PostRequestMessage);
             var PostJsonString = await PostResult.Content.ReadAsStringAsync();
             var postID = JsonConvert.DeserializeObject<int>(PostJsonString);
 
             //DELETE
-            var DeleteRequestMessage = CreateRequest(HttpMethod.Delete, $"post/{postID}");
-            var DeleteResult = await client.SendAsync(DeleteRequestMessage);
+            var DeleteRequestMessage = API.CreateRequest(HttpMethod.Delete, $"post/{postID}");
+            var DeleteResult = await API.client.SendAsync(DeleteRequestMessage);
             var DeleteJsonString = await DeleteResult.Content.ReadAsStringAsync();
             var isDeleted = JsonConvert.DeserializeObject<bool>(DeleteJsonString);
 
             //GET
-            var PutRequestMessage = CreateRequest(HttpMethod.Get, $"post/{postID}");
-            var PutResult = await client.SendAsync(PutRequestMessage);
+            var PutRequestMessage = API.CreateRequest(HttpMethod.Get, $"post/{postID}");
+            var PutResult = await API.client.SendAsync(PutRequestMessage);
 
             Assert.Equal(HttpStatusCode.OK, PostResult.StatusCode);
             Assert.Equal(HttpStatusCode.OK, DeleteResult.StatusCode);

--- a/WebApi/IntegrationTest/Extensions/IQueryableExtension.cs
+++ b/WebApi/IntegrationTest/Extensions/IQueryableExtension.cs
@@ -1,0 +1,15 @@
+﻿using System.Linq;
+
+namespace IntegrationTest.Extensions
+{
+    public static class IQueryableExtension
+    {
+        public static int Count(this IQueryable query)
+        {
+            int count = 0;
+            foreach (var o in query)
+                count++;
+            return count;
+        }
+    }
+}

--- a/WebApi/IntegrationTest/IntegrationTest/CategoryIntegrationTest.cs
+++ b/WebApi/IntegrationTest/IntegrationTest/CategoryIntegrationTest.cs
@@ -1,0 +1,81 @@
+﻿
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using WebApi.Controllers;
+using WebApi.Database;
+using WebApi.Database.Repositories.Implementations;
+using WebApi.Models.DTO;
+using WebApi.Models.POCO;
+using WebApi.Services.Serives_Implementations;
+using Xunit;
+
+namespace IntegrationTest
+{
+    public class CategoryIntegrationTest
+    {
+        public CategoryController GetCategoryController(DbContextOptions<DatabaseContext> options)
+        {
+            var logger = new Mock<ILogger<CategoryController>>();
+            var databaseContext = new DatabaseContext(options);
+            var categoryRepository = new CategoryRepository(databaseContext);
+            var categoryService = new CategoryService(categoryRepository);
+            var categoryController = new CategoryController(logger.Object, categoryService);
+
+            return categoryController;
+        }
+
+        [Fact]
+        public void GetCategories_ValidCall()
+        {
+            var options = new DbContextOptionsBuilder<DatabaseContext>()
+               .UseInMemoryDatabase(databaseName: "GetCategories_ValidCall").Options;
+            var categories = new List<Category>{
+                new Category { CategoryID = 1, Name = "test1"},
+                new Category { CategoryID = 2, Name = "test2"},
+                new Category { CategoryID = 3, Name = "test3"},
+                new Category { CategoryID = 4, Name = "test4"}
+            };
+
+            using (var dbContext = new DatabaseContext(options))
+            {
+                foreach (var category in categories)
+                    dbContext.Add(category);
+                dbContext.SaveChanges();
+            }
+
+            var categoryController = GetCategoryController(options);
+            
+            var actual = (Categories)((ObjectResult)categoryController.GetAll().Result).Value;
+            var count = actual.categories.Count();
+            Assert.NotNull(actual);
+            Assert.NotEmpty(actual.categories);
+            Assert.Equal(4, count);
+            foreach(var category in actual.categories)
+            {
+                Assert.NotNull(category.Name);
+                Assert.NotEqual("", category.Name);
+            }    
+        }
+
+        [Fact]
+        public void GetCategories_ValidCall_Empty()
+        {
+            var options = new DbContextOptionsBuilder<DatabaseContext>()
+               .UseInMemoryDatabase(databaseName: "GetCategories_ValidCall_Empty").Options;
+
+            var categoryController = GetCategoryController(options);
+
+            var actual = (Categories)((ObjectResult)categoryController.GetAll().Result).Value;
+
+            Assert.NotNull(actual);
+            Assert.Empty(actual.categories);
+        }
+
+    }
+}

--- a/WebApi/WebApi/Controllers/CategoryController.cs
+++ b/WebApi/WebApi/Controllers/CategoryController.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using WebApi.Models.DTO;
+using WebApi.Services;
 using WebApi.Services.Services_Interfaces;
 
 namespace WebApi.Controllers
@@ -21,10 +22,10 @@ namespace WebApi.Controllers
         }
 
         [HttpGet("categories")]
-        public ActionResult<IQueryable<CategoryDTO>> GetAll()
+        public ActionResult<Categories> GetAll()
         {
             var result = _categoryService.GetAll();
-            return new ControllerResult<IQueryable<CategoryDTO>>(result).GetResponse();
+            return new ControllerResult<Categories>(result).GetResponse();
         }
 
         [HttpGet("categories/{categoryId}")]

--- a/WebApi/WebApi/Database/Mapper/Mapper.cs
+++ b/WebApi/WebApi/Database/Mapper/Mapper.cs
@@ -277,12 +277,12 @@ namespace WebApi.Database.Mapper
         public static Category Map(CategoryDTO categoryDTO)
         {
             if (categoryDTO == null) return null;
-            return new Category { CategoryID = categoryDTO.CategoryID.Value, Name = categoryDTO.Name };
+            return new Category { CategoryID = categoryDTO.ID.Value, Name = categoryDTO.Name };
         }
         public static CategoryDTO Map(Category category)
         {
             if (category == null) return null;
-            return new CategoryDTO { CategoryID = category.CategoryID, Name = category.Name };
+            return new CategoryDTO { ID = category.CategoryID, Name = category.Name };
         }
         public static IQueryable<CategoryDTO> Map(IQueryable<Category> categories)
         {

--- a/WebApi/WebApi/Models/DTO/Categories.cs
+++ b/WebApi/WebApi/Models/DTO/Categories.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace WebApi.Models.DTO
+{
+    public class Categories
+    {
+        public IQueryable<CategoryDTO> categories;
+    }
+}

--- a/WebApi/WebApi/Models/DTO/CategoryDTO.cs
+++ b/WebApi/WebApi/Models/DTO/CategoryDTO.cs
@@ -10,7 +10,7 @@ namespace WebApi.Models.DTO
     {
         [Key]
         [Required]
-        public int? CategoryID { get; set; }
+        public int? ID { get; set; }
         
         [Required]
         [MaxLength(50)]

--- a/WebApi/WebApi/Services/Services Implementations/CategoryService.cs
+++ b/WebApi/WebApi/Services/Services Implementations/CategoryService.cs
@@ -16,10 +16,11 @@ namespace WebApi.Services.Serives_Implementations
         {
             _categoryRepository = categoryRepository;
         }
-        public ServiceResult<IQueryable<CategoryDTO>> GetAll()
+        public ServiceResult<Categories> GetAll()
         {
             var result = _categoryRepository.GetAll();
-            return new ServiceResult<IQueryable<CategoryDTO>>(Mapper.Map(result.Result), result.Code, result.Message);
+            var categories = new Categories { categories = Mapper.Map(result.Result) };
+            return new ServiceResult<Categories>(categories, result.Code, result.Message);
         }
 
         public ServiceResult<CategoryDTO> GetById(int categoryId)

--- a/WebApi/WebApi/Services/Services Interfaces/ICategoryService.cs
+++ b/WebApi/WebApi/Services/Services Interfaces/ICategoryService.cs
@@ -9,7 +9,7 @@ namespace WebApi.Services.Services_Interfaces
 {
     public interface ICategoryService
     {
-        public ServiceResult<IQueryable<CategoryDTO>> GetAll();
+        public ServiceResult<Categories> GetAll();
         public ServiceResult<CategoryDTO> GetById(int categoryId);
     }
 }

--- a/WebApi/WebApiTest/ControllerTest/CategoryControllerTest.cs
+++ b/WebApi/WebApiTest/ControllerTest/CategoryControllerTest.cs
@@ -28,7 +28,7 @@ namespace WebApiTest.ControllerTest
             mockService.Setup(x => x.GetById(id)).Returns(new ServiceResult<CategoryDTO>(new CategoryDTO
 
             {
-                CategoryID = id,
+                ID = id,
                 Name=name
             }));
 
@@ -38,14 +38,14 @@ namespace WebApiTest.ControllerTest
             var expected = new CategoryDTO
 
             {
-                CategoryID = id,
+                ID = id,
                 Name = name
             };
 
 
             var actual = (CategoryDTO)((ObjectResult)controller.GetById(id).Result).Value;
 
-            Assert.Equal(expected.CategoryID, actual.CategoryID);
+            Assert.Equal(expected.ID, actual.ID);
             Assert.Equal(expected.Name, actual.Name);
         }
 
@@ -55,29 +55,29 @@ namespace WebApiTest.ControllerTest
         [InlineData(2, "Kategoria4")]
         public void GetAll_Test(int id, string name)
         {
-            List<CategoryDTO> categories = new List<CategoryDTO>();
-            categories.Add(new CategoryDTO
+            List<CategoryDTO> category = new List<CategoryDTO>();
+            category.Add(new CategoryDTO
             {
-                CategoryID = id,
+                ID = id,
                 Name = name
             });
-            categories.Add(new CategoryDTO
+            category.Add(new CategoryDTO
             {
-                CategoryID = id+1,
+                ID = id+1,
                 Name = name+"cokolwiek"
             });
+            var categories = new Categories { categories = category.AsQueryable() };
             var mockService = new Mock<ICategoryService>();
-            mockService.Setup(x => x.GetAll()).Returns(new ServiceResult<IQueryable<CategoryDTO>>(categories.AsQueryable()
-            ));
+            mockService.Setup(x => x.GetAll()).Returns(new ServiceResult<Categories>(categories));
 
             var mockLogger = new Mock<ILogger<CategoryController>>();
             var controller = new CategoryController(mockLogger.Object, mockService.Object);
 
             var expected = categories;
 
-            var actual = ((IEnumerable<CategoryDTO>)((ObjectResult)controller.GetAll().Result).Value).ToList();
+            var actual = ((Categories)((ObjectResult)controller.GetAll().Result).Value).categories.ToList();
 
-            Assert.True(expected.All(shouldItem => actual.Any(isItem => isItem.CategoryID == shouldItem.CategoryID && isItem.Name==shouldItem.Name)));
+            Assert.True(expected.categories.All(shouldItem => actual.Any(isItem => isItem.ID == shouldItem.ID && isItem.Name==shouldItem.Name)));
 
 
         }

--- a/WebApi/WebApiTest/MapperTest/MapperTest.cs
+++ b/WebApi/WebApiTest/MapperTest/MapperTest.cs
@@ -272,9 +272,9 @@ namespace WebApiTest.MapperTest
 
         public static IEnumerable<object[]> CategoryDTOData()
         {
-            yield return new object[] { new CategoryDTO { CategoryID = 1, Name = "test1" } };
-            yield return new object[] { new CategoryDTO { CategoryID = 0, Name = "" } };
-            yield return new object[] { new CategoryDTO { CategoryID = int.MaxValue, Name = "2" } };
+            yield return new object[] { new CategoryDTO { ID = 1, Name = "test1" } };
+            yield return new object[] { new CategoryDTO { ID = 0, Name = "" } };
+            yield return new object[] { new CategoryDTO { ID = int.MaxValue, Name = "2" } };
         }
 
         public static IEnumerable<object[]> CategoryDTOList()
@@ -284,9 +284,9 @@ namespace WebApiTest.MapperTest
                 new List<CategoryDTO>
                 {
 
-                    new CategoryDTO() { CategoryID=0,Name="test1" },
-                    new CategoryDTO() { CategoryID=int.MaxValue, Name="test2" },
-                    new CategoryDTO() {  CategoryID=1, Name="" },
+                    new CategoryDTO() { ID=0,Name="test1" },
+                    new CategoryDTO() { ID=int.MaxValue, Name="test2" },
+                    new CategoryDTO() {  ID=1, Name="" },
                 }
 
              };
@@ -312,9 +312,9 @@ namespace WebApiTest.MapperTest
         [InlineData(5, "Jakas kategoria")]
         public void CategoryDTOtoPOCOMapping(int id, string name)
         {
-            CategoryDTO categoryDTO = new CategoryDTO { CategoryID = id, Name = name };
+            CategoryDTO categoryDTO = new CategoryDTO { ID = id, Name = name };
             Category category = Mapper.Map(categoryDTO);
-            Assert.Equal(categoryDTO.CategoryID, category.CategoryID);
+            Assert.Equal(categoryDTO.ID, category.CategoryID);
             Assert.Equal(categoryDTO.Name, category.Name);
         }
 
@@ -326,7 +326,7 @@ namespace WebApiTest.MapperTest
         {
             Category category = new Category { CategoryID = id, Name = name };
             CategoryDTO categoryDTO = Mapper.Map(category);
-            Assert.Equal(categoryDTO.CategoryID, category.CategoryID);
+            Assert.Equal(categoryDTO.ID, category.CategoryID);
             Assert.Equal(categoryDTO.Name, category.Name);
         }
 
@@ -338,7 +338,7 @@ namespace WebApiTest.MapperTest
 
 
             Assert.True(result.All(result => input.Any(isItem =>
-                isItem.CategoryID == result.CategoryID &&
+                isItem.CategoryID == result.ID &&
                 isItem.Name == result.Name
             )));
         }
@@ -351,7 +351,7 @@ namespace WebApiTest.MapperTest
 
 
             Assert.True(result.All(result => input.Any(isItem =>
-                isItem.CategoryID == result.CategoryID &&
+                isItem.ID == result.CategoryID &&
                 isItem.Name == result.Name
             )));
         }

--- a/WebApi/WebApiTest/ServiceTest/CategoryServiceTest.cs
+++ b/WebApi/WebApiTest/ServiceTest/CategoryServiceTest.cs
@@ -33,11 +33,11 @@ namespace WebApiTest.ServiceTest
                 .Returns(new ServiceResult<IQueryable<Category>>(categories.AsQueryable()));
 
             var categoryService = new CategoryService(mockICategoryRepository.Object);
-            var actual = categoryService.GetAll().Result.ToList();
+            var actual = categoryService.GetAll().Result.categories.ToList();
 
             Assert.True(actual != null);
             Assert.Equal(expected.Count, actual.Count);
-            Assert.True(expected.All(shouldItem => actual.Any(isItem => isItem.CategoryID == shouldItem.CategoryID && isItem.Name == shouldItem.Name)));
+            Assert.True(expected.All(shouldItem => actual.Any(isItem => isItem.ID == shouldItem.CategoryID && isItem.Name == shouldItem.Name)));
 
         }
 
@@ -57,7 +57,7 @@ namespace WebApiTest.ServiceTest
             var expected2 = expected.Result;
 
             Assert.True(actual != null);
-            Assert.Equal(expected2.CategoryID, actual.CategoryID);
+            Assert.Equal(expected2.CategoryID, actual.ID);
             Assert.Equal(expected2.Name, actual.Name);
 
         }


### PR DESCRIPTION
Wprowadzone zmiany w zasobie Category wymagają poprawienia go w WallProject
Nie jest on już przekazywany jako IQueryable<CategoryDTO> tylko jako obiekt zawierający IQueryable<CategoryDTO> i nazwie 'categories'. Dodatkowo w CategoryDTO zostało zmienione pole CategoryID na ID.